### PR TITLE
CVE-2016-6580

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+1.2.0 (2016-08-04)
+------------------
+
+**Security Fixes**
+
+- CVE-2016-6580: All versions of this library prior to 1.2.0 are vulnerable to
+  a denial of service attack whereby a remote peer can cause a user to insert
+  an unbounded number of streams into the priority tree, eventually consuming
+  all available memory.
+
+  This version adds a ``TooManyStreamsError`` exception that is raised when
+  too many streams are inserted into the priority tree. It also adds a keyword
+  argument to the priority tree, ``maximum_streams``, which limits how many
+  streams may be inserted. By default, this number is set to 1000.
+  Implementations should strongly consider whether they can set this value
+  lower.
+
 1.1.1 (2016-05-28)
 ------------------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,3 +17,5 @@ Exceptions
 .. autoclass:: priority.DuplicateStreamError
 
 .. autoclass:: priority.MissingStreamError
+
+.. autoclass:: priority.TooManyStreamsError

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ Contents:
    installation
    using-priority
    api
+   security/index
    license
    authors
 

--- a/docs/source/security/CVE-2016-6580.rst
+++ b/docs/source/security/CVE-2016-6580.rst
@@ -1,0 +1,64 @@
+:orphan:
+
+DoS via Unlimited Stream Insertion
+==================================
+
+Hyper Project security advisory, August 4th 2016.
+
+Vulnerability
+-------------
+
+A HTTP/2 implementation built using the priority library could be targetted by
+a malicious peer by having that peer assign priority information for every
+possible HTTP/2 stream ID. The priority tree would happily continue to store
+the priority information for each stream, and would therefore allocate
+unbounded amounts of memory. Attempting to actually *use* a tree like this
+would also cause extremely high CPU usage to maintain the tree.
+
+We are not aware of any active exploits of this vulnerability, but as this
+class of attack was publicly described in `this report`_, users should assume
+that they are at imminent risk of this kind of attack.
+
+Info
+----
+
+This issue has been given the name CVE-2016-6580.
+
+Affected Versions
+-----------------
+
+This issue affects all versions of the priority library prior to 1.2.0.
+
+The Solution
+------------
+
+In version 1.2.0, the priority library limits the maximum number of streams
+that can be inserted into the tree. By default this limit is 1000, but it is
+user-configurable.
+
+If it is necessary to backport a patch, the patch can be found in
+`this GitHub pull request`_.
+
+Recommendations
+---------------
+
+We suggest you take the following actions immediately, in order of preference:
+
+1. Update priority to 1.2.0 immediately, and consider revising the maximum
+   number of streams downward to a suitable value for your application.
+2. Backport the patch made available on GitHub.
+3. Manually enforce a limit on the number of priority settings you'll allow at
+   once.
+
+Timeline
+--------
+
+This class of vulnerability was publicly reported in `this report`_ on the
+3rd of August. We requested a CVE ID from Mitre the same day.
+
+Priority 1.2.0 was released on the 4th of August, at the same time as the
+publication of this advisory.
+
+
+.. _this report: http://www.imperva.com/docs/Imperva_HII_HTTP2.pdf
+.. _this GitHub pull request: https://github.com/python-hyper/priority/pull/23

--- a/docs/source/security/index.rst
+++ b/docs/source/security/index.rst
@@ -1,0 +1,19 @@
+Vulnerability Notifications
+===========================
+
+This section of the page contains all known vulnerabilities in the priority
+library. These vulnerabilities have all been reported to us via our
+`vulnerability disclosure policy`_.
+
+Known Vulnerabilities
+---------------------
+
++----+---------------------------+----------------+---------------+--------------+---------------+
+| \# |       Vulnerability       | Date Announced | First Version | Last Version |      CVE      |
++====+===========================+================+===============+==============+===============+
+| 1  | :doc:`DoS via unlimited   | 2016-08-04     | 1.0.0         | 1.1.1        | CVE-2016-6580 |
+|    | stream insertion.         |                |               |              |               |
+|    | <CVE-2016-6580>`          |                |               |              |               |
++----+---------------------------+----------------+---------------+--------------+---------------+
+
+.. _vulnerability disclosure policy: http://python-hyper.org/en/latest/security.html#vulnerability-disclosure

--- a/src/priority/__init__.py
+++ b/src/priority/__init__.py
@@ -4,5 +4,5 @@ priority: HTTP/2 priority implementation for Python
 """
 from .priority import (  # noqa
     Stream, PriorityTree, DeadlockError, PriorityLoop, DuplicateStreamError,
-    MissingStreamError
+    MissingStreamError, TooManyStreamsError
 )

--- a/test/test_priority.py
+++ b/test/test_priority.py
@@ -292,6 +292,21 @@ class TestPriorityTreeManual(object):
         with pytest.raises(priority.MissingStreamError):
             p.remove_stream(3)
 
+    @pytest.mark.parametrize('count', range(2, 10000, 100))
+    def test_priority_refuses_to_allow_too_many_streams_in_tree(self, count):
+        """
+        Attempting to insert more streams than maximum_streams into the tree
+        fails.
+        """
+        p = priority.PriorityTree(maximum_streams=count)
+
+        # This isn't an off-by-one error: stream 0 is in the tree by default.
+        for x in range(1, count):
+            p.insert_stream(x)
+
+        with pytest.raises(priority.TooManyStreamsError):
+            p.insert_stream(x + 1)
+
 
 class TestPriorityTreeOutput(object):
     """


### PR DESCRIPTION
The library is vulnerable to a denial of service attack whereby a remote peer
can insert an unbounded number of streams into the priority tree. This consumes
unbounded memory and also increasingly large amounts of CPU, which can
lead to a trivial denial of service against a HTTP/2 server. This vulnerability
is part of a class of vulnerabilities originally reported in [this report](http://www.imperva.com/docs/Imperva_HII_HTTP2.pdf),
under the section "Victim 3-Dependency and Priority". The document notes in
passing that the dependency tree size is not limited, and that "a server that
naively trusts the client may be foiled to build a dependency tree that will
consume its memory". This is exactly the attack that the priority library is
exposed to.

Sample code to reproduce the vulnerability is below:

    import priority

    tree = priority.PriorityTree()
    x = 1

    while True:
        tree.insert_stream(x)
        x += 1


This code will run indefinitely, and eventually exhaust the memory available
to it.