### PR TITLE
Improve error messages when handling stream 0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ Changelog
   weight that is not an integer between 1 and 256, inclusive.
 - Throw ``PseudoStreamError`` when trying to reprioritise, remove, block or
   unblock stream 0.
+- Add a new ``PriorityError`` parent class for the exceptions that can be
+  thrown by priority.
 
 1.2.2 (2016-11-11)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Changelog
 
 - Throw ``BadWeightError`` when creating or reprioritising a stream with a
   weight that is not an integer between 1 and 256, inclusive.
-- Throw ``PseudoStreamError`` when trying to reprioritize, remove, block or
+- Throw ``PseudoStreamError`` when trying to reprioritise, remove, block or
   unblock stream 0.
 
 1.2.2 (2016-11-11)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Changelog
 
 - Throw ``BadWeightError`` when creating or reprioritising a stream with a
   weight that is not an integer between 1 and 256, inclusive.
+- Throw ``PseudoStreamError`` when trying to reprioritize, remove, block or
+  unblock stream 0.
 
 1.2.2 (2016-11-11)
 ------------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,3 +19,7 @@ Exceptions
 .. autoclass:: priority.MissingStreamError
 
 .. autoclass:: priority.TooManyStreamsError
+
+.. autoclass:: priority.BadWeightError
+
+.. autoclass:: priority.PseudoStreamError

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,6 +10,8 @@ Priority Tree
 Exceptions
 ----------
 
+.. autoclass:: priority.PriorityError
+
 .. autoclass:: priority.DeadlockError
 
 .. autoclass:: priority.PriorityLoop

--- a/src/priority/__init__.py
+++ b/src/priority/__init__.py
@@ -4,5 +4,5 @@ priority: HTTP/2 priority implementation for Python
 """
 from .priority import (  # noqa
     Stream, PriorityTree, DeadlockError, PriorityLoop, DuplicateStreamError,
-    MissingStreamError, TooManyStreamsError, BadWeightError
+    MissingStreamError, TooManyStreamsError, BadWeightError, PseudoStreamError
 )

--- a/src/priority/priority.py
+++ b/src/priority/priority.py
@@ -429,6 +429,9 @@ class PriorityTree(object):
 
         :param stream_id: The ID of the stream to block.
         """
+        if stream_id == 0:
+            raise PseudoStreamError("Cannot block stream 0")
+
         try:
             self._streams[stream_id].active = False
         except KeyError:
@@ -440,6 +443,9 @@ class PriorityTree(object):
 
         :param stream_id: The ID of the stream to unblock.
         """
+        if stream_id == 0:
+            raise PseudoStreamError("Cannot unblock stream 0")
+
         try:
             self._streams[stream_id].active = True
         except KeyError:

--- a/src/priority/priority.py
+++ b/src/priority/priority.py
@@ -62,6 +62,15 @@ class BadWeightError(Exception):
     pass
 
 
+class PseudoStreamError(Exception):
+    """
+    An operation was attempted on stream 0.
+
+    .. versionadded:: 1.3.0
+    """
+    pass
+
+
 class Stream(object):
     """
     Priority information for a given stream.
@@ -339,6 +348,9 @@ class PriorityTree(object):
         :param exclusive: (optional) Whether this stream should now be an
             exclusive dependency of the new parent.
         """
+        if stream_id == 0:
+            raise PseudoStreamError("Cannot reprioritize stream 0")
+
         def stream_cycle(new_parent, current):
             """
             Reports whether the new parent depends on the current stream.
@@ -400,6 +412,9 @@ class PriorityTree(object):
 
         :param stream_id: The ID of the stream to remove.
         """
+        if stream_id == 0:
+            raise PseudoStreamError("Cannot remove stream 0")
+
         try:
             child = self._streams.pop(stream_id)
         except KeyError:
@@ -425,7 +440,6 @@ class PriorityTree(object):
 
         :param stream_id: The ID of the stream to unblock.
         """
-        # When a stream becomes unblocked,
         try:
             self._streams[stream_id].active = True
         except KeyError:

--- a/test/test_priority.py
+++ b/test/test_priority.py
@@ -296,6 +296,19 @@ class TestPriorityTreeManual(object):
         with pytest.raises(priority.MissingStreamError):
             p.remove_stream(3)
 
+    def test_priority_raises_good_errors_for_zero_stream(self):
+        """
+        Attempting operations on stream 0 raises a PseudoStreamError.
+        """
+        p = priority.PriorityTree()
+        p.insert_stream(1)
+
+        with pytest.raises(priority.PseudoStreamError):
+            p.reprioritize(0)
+
+        with pytest.raises(priority.PseudoStreamError):
+            p.remove_stream(0)
+
     @pytest.mark.parametrize('exclusive', [True, False])
     def test_priority_allows_inserting_stream_with_absent_parent(self,
                                                                  exclusive):

--- a/test/test_priority.py
+++ b/test/test_priority.py
@@ -307,6 +307,12 @@ class TestPriorityTreeManual(object):
             p.reprioritize(0)
 
         with pytest.raises(priority.PseudoStreamError):
+            p.block(0)
+
+        with pytest.raises(priority.PseudoStreamError):
+            p.unblock(0)
+
+        with pytest.raises(priority.PseudoStreamError):
             p.remove_stream(0)
 
     @pytest.mark.parametrize('exclusive', [True, False])


### PR DESCRIPTION
I’m not sure if I should provide a better message about stream 0 being “special”, but at least the traceback no longer comes from halfway inside priority.

Fixes #48.