### PR TITLE
Allow test_period_of_repetition to be slow

### DIFF
--- a/test/test_priority.py
+++ b/test/test_priority.py
@@ -12,7 +12,7 @@ import itertools
 
 import pytest
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.stateful import invariant, RuleBasedStateMachine, rule
 from hypothesis.strategies import (
     integers, lists, tuples, sampled_from
@@ -503,6 +503,7 @@ class TestPriorityTreeOutput(object):
     fairness and equidistribution.
     """
     @given(STREAMS_AND_WEIGHTS)
+    @settings(deadline=500)
     def test_period_of_repetition(self, streams_and_weights):
         """
         The period of repetition of a priority sequence is given by the sum of


### PR DESCRIPTION
Recent versions of hypothesis default to a 200ms timeout, which wasn't enough for my Thinkpad X220 to run this test. I've increased the timeout for this single test to hopefully a reasonable amount for older hardware.