### PR TITLE
typing, mypy, black

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changelog
 - Support for PyPy (Python 2.7 compatible) has been removed.
 - Support for Python 3.8 has been added.
 - Support for Python 3.9 has been added.
+- Add type hints throughout and support PEP 561 via a py.typed
+  file. This should allow projects to type check their usage of this dependency.
 - Throw ``TypeError`` when creating a priority tree with a ``maximum_streams``
   value that is not an integer.
 - Throw ``ValueError`` when creating a priority tree with a ``maximum_streams``

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,5 @@ graft visualizer
 graft examples
 prune docs/build
 recursive-include *.py
-include README.rst LICENSE CONTRIBUTORS.rst HISTORY.rst tox.ini
+include README.rst LICENSE CHANGELOG.rst CONTRIBUTORS.rst tox.ini
 global-exclude *.pyc *.pyo *.swo *.swp *.map *.yml *.DS_Store

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,14 @@ source =
 [flake8]
 max-line-length = 120
 max-complexity = 10
+
+[mypy]
+strict = true
+warn_unused_configs = true
+show_error_codes = true
+
+[mypy-test_priority]
+allow_untyped_defs = true
+check_untyped_defs = false
+ignore_missing_imports = true
+disallow_subclassing_any = false

--- a/src/priority/__init__.py
+++ b/src/priority/__init__.py
@@ -3,10 +3,17 @@
 priority: HTTP/2 priority implementation for Python
 """
 from .priority import (  # noqa
-    Stream, PriorityTree, DeadlockError, PriorityLoop, PriorityError,
-    DuplicateStreamError, MissingStreamError, TooManyStreamsError,
-    BadWeightError, PseudoStreamError
+    Stream,
+    PriorityTree,
+    DeadlockError,
+    PriorityLoop,
+    PriorityError,
+    DuplicateStreamError,
+    MissingStreamError,
+    TooManyStreamsError,
+    BadWeightError,
+    PseudoStreamError,
 )
 
 
-__version__ = '2.0.0+dev'
+__version__ = "2.0.0+dev"

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,14 @@ commands = pytest {posargs}
 
 [testenv:lint]
 deps =
-    flake8>=3.9.1,<4
-commands = flake8 src/ test/
+    flake8>=3.8,<4
+    black==21.5b2
+    mypy==0.902
+    {[testenv]deps}
+commands =
+    flake8 src/ test/
+    black --check --diff src/ test/
+    mypy src/ test/
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
based on and closes #138

This PR introduces full type hinting
This PR fully integrates strict mypy checks into our linting CI step.
This PR adopts black as *the* code formatter and enforces it via an CI step (including the previously existing flake8 check).

@graingert thanks for the foundation in #138 - I built this PR on top of your proposed changes. 🎉 