### PR TITLE
Correct a warning in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,5 @@ graft test
 graft visualizer
 graft examples
 prune docs/build
-recursive-include *.py
 include README.rst LICENSE CHANGELOG.rst CONTRIBUTORS.rst tox.ini
 global-exclude *.pyc *.pyo *.swo *.swp *.map *.yml *.DS_Store


### PR DESCRIPTION
```
warning: manifest_maker: MANIFEST.in, line 7: 'recursive-include' expects <dir> <pattern1> <pattern2> ...
```