### PR TITLE
Update intersphinx_mapping for Sphinx 8 compatibility

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 exclude_patterns = []
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('http://docs.python.org/', None)}
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This makes the `intersphinx_mapping` in `docs/source/conf.py` forward-compatible with Sphinx 8 by changing it from


```python
intersphinx_mapping = {'https://docs.python.org/3/': None}
```

to

```python
intersphinx_mapping = {'python': ('https://docs.python.org/3/', None)}
```