### PR TITLE
Drop support for end-of-life versions of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,19 @@ jobs:
   tox:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      fail-fast: false
       matrix:
         python-version:
-        - 3.6
-        - 3.7
-        - 3.8
-        - 3.9
-        - pypy3
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
+        - "pypy3.11"
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,12 +14,12 @@ import os
 import sys
 import re
 
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath("../.."))
 
 PROJECT_ROOT = os.path.dirname(__file__)
 # Get the version
 version_regex = r'__version__ = ["\']([^"\']*)["\']'
-with open(os.path.join(PROJECT_ROOT, '../../', 'src/priority/__init__.py')) as file_:
+with open(os.path.join(PROJECT_ROOT, "../../", "src/priority/__init__.py")) as file_:
     text = file_.read()
     match = re.search(version_regex, text)
     version = match.group(1)
@@ -27,9 +27,9 @@ with open(os.path.join(PROJECT_ROOT, '../../', 'src/priority/__init__.py')) as f
 
 # -- Project information -----------------------------------------------------
 
-project = 'priority'
-copyright = '2021, Cory Benfield'
-author = 'Cory Benfield'
+project = "priority"
+copyright = "2021, Cory Benfield"
+author = "Cory Benfield"
 release = version
 
 # -- General configuration ------------------------------------------------
@@ -38,29 +38,29 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = []
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('http://docs.python.org/', None)}
+intersphinx_mapping = {"python": ("http://docs.python.org/", None)}
 
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = "default"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ from setuptools import setup, find_packages
 
 PROJECT_ROOT = os.path.dirname(__file__)
 
-with open(os.path.join(PROJECT_ROOT, 'README.rst')) as file_:
+with open(os.path.join(PROJECT_ROOT, "README.rst")) as file_:
     long_description = file_.read()
 
 version_regex = r'__version__ = ["\']([^"\']*)["\']'
-with open(os.path.join(PROJECT_ROOT, 'src/priority/__init__.py')) as file_:
+with open(os.path.join(PROJECT_ROOT, "src/priority/__init__.py")) as file_:
     text = file_.read()
     match = re.search(version_regex, text)
     if match:
@@ -20,36 +20,36 @@ with open(os.path.join(PROJECT_ROOT, 'src/priority/__init__.py')) as file_:
         raise RuntimeError("No version number found!")
 
 setup(
-    name='priority',
+    name="priority",
     version=version,
-    description='A pure-Python implementation of the HTTP/2 priority tree',
+    description="A pure-Python implementation of the HTTP/2 priority tree",
     long_description=long_description,
-    long_description_content_type='text/x-rst',
-    author='Cory Benfield',
-    author_email='cory@lukasa.co.uk',
-    url='https://github.com/python-hyper/priority/',
+    long_description_content_type="text/x-rst",
+    author="Cory Benfield",
+    author_email="cory@lukasa.co.uk",
+    url="https://github.com/python-hyper/priority/",
     project_urls={
-        'Documentation': 'https://python-hyper.org/projects/priority/',
-        'Source': 'https://github.com/python-hyper/priority/',
-        'Tracker': 'https://github.com/python-hyper/priority/issues',
-        'Changelog': 'https://github.com/python-hyper/priority/blob/master/HISTORY.rst',
+        "Documentation": "https://python-hyper.org/projects/priority/",
+        "Source": "https://github.com/python-hyper/priority/",
+        "Tracker": "https://github.com/python-hyper/priority/issues",
+        "Changelog": "https://github.com/python-hyper/priority/blob/master/HISTORY.rst",
     },
-    packages=find_packages(where='src'),
-    package_data={'priority': ['py.typed']},
-    package_dir={'': 'src'},
-    python_requires='>=3.6.1',
-    license='MIT License',
+    packages=find_packages(where="src"),
+    package_data={"priority": ["py.typed"]},
+    package_dir={"": "src"},
+    python_requires=">=3.10.0",
+    license="MIT License",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
 )

--- a/test/test_priority.py
+++ b/test/test_priority.py
@@ -118,8 +118,8 @@ class TestStream:
         assert sorted(streams_by_id) == streams_by_id
 
     @given(
-        integers(min_value=1, max_value=2 ** 24),
-        integers(min_value=1, max_value=2 ** 24),
+        integers(min_value=1, max_value=2**24),
+        integers(min_value=1, max_value=2**24),
     )
     def test_stream_ordering(self, a, b):
         """
@@ -554,7 +554,7 @@ class PriorityStateMachine(RuleBasedStateMachine):
         self.stream_ids = set([0])
         self.blocked_stream_ids = set()
 
-    @rule(stream_id=integers())  # type: ignore[no-untyped-call]
+    @rule(stream_id=integers())
     def insert_stream(self, stream_id):
         try:
             self.tree.insert_stream(stream_id)
@@ -574,24 +574,24 @@ class PriorityStateMachine(RuleBasedStateMachine):
         else:
             assert stream_id in self.stream_ids
 
-    @rule(stream_id=integers())  # type: ignore[no-untyped-call]
+    @rule(stream_id=integers())
     def remove_stream(self, stream_id):
         self._run_action(self.tree.remove_stream, stream_id)
         if stream_id != 0:
             self.stream_ids.discard(stream_id)
 
-    @rule(stream_id=integers())  # type: ignore[no-untyped-call]
+    @rule(stream_id=integers())
     def block_stream(self, stream_id):
         self._run_action(self.tree.block, stream_id)
         if (stream_id != 0) and (stream_id in self.stream_ids):
             self.blocked_stream_ids.add(stream_id)
 
-    @rule(stream_id=integers())  # type: ignore[no-untyped-call]
+    @rule(stream_id=integers())
     def unblock_stream(self, stream_id):
         self._run_action(self.tree.unblock, stream_id)
         self.blocked_stream_ids.discard(stream_id)
 
-    @invariant()  # type: ignore[no-untyped-call]
+    @invariant()
     def check_next_stream_consistent(self):
         """
         If we ask priority for the next stream, it always returns a sensible

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,23 @@
 [tox]
-envlist = py36, py37, py38, py39, pypy3, lint, docs, packaging
+envlist = py310, py311, py312, py313, py314, pypy3, lint, docs, packaging
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39, lint, docs, packaging
+    3.10: py310, lint, docs, packaging
+    3.11: py311
+    3.12: py312
+    3.13: py313
+    3.14: py314
     pypy3: pypy3
 
 [testenv]
 passenv =
     GITHUB_*
 deps =
-    pytest>=6.2,<7
-    pytest-cov>=2.10,<3
-    pytest-xdist>=2.1,<3
-    hypothesis>=6.9,<7
+    pytest
+    pytest-cov
+    pytest-xdist
+    hypothesis
 commands =
     pytest --cov-report=xml  --cov-report=term --cov=priority {posargs}
 
@@ -26,10 +27,13 @@ commands = pytest {posargs}
 
 [testenv:lint]
 deps =
-    flake8>=3.8,<4
-    black==21.6b0
+    flake8
+    black
+    hypothesis
     mypy==0.910
-    {[testenv]deps}
+    pytest>=6.2,<7
+    typed_ast
+    # {[testenv]deps}
 commands =
     flake8 src/ test/
     black --check --diff src/ test/
@@ -37,20 +41,20 @@ commands =
 
 [testenv:docs]
 deps =
-    sphinx>=3.5,<5
-whitelist_externals = make
+    sphinx
+allowlist_externals = make
 changedir = {toxinidir}/docs
 commands =
     make clean
     make html
 
 [testenv:packaging]
-basepython = python3.9
+basepython = python3.10
 deps =
-    check-manifest==0.46
-    readme-renderer==29.0
-    twine>=3.4.1,<4
-whitelist_externals = rm
+    check-manifest
+    readme-renderer
+    twine
+allowlist_externals = rm
 commands =
     rm -rf dist/
     check-manifest


### PR DESCRIPTION
Our GitHub Actions [currently fail](https://github.com/python-hyper/priority/actions ) ❌ because `ubuntu-latest` no longer supports Python versions less than 3.8 so let’s drop them so that our CI tests are green. ✅

Python versions less than 3.10 are end-of-life so perhaps we should drop testing of all EoL versions of Python.